### PR TITLE
tool: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.6.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-added-large-files
+- repo: local
+  hooks:
+    - name: golangci-lint
+      id: golangci-lint
+      description: Run golangci-lint.
+      entry: golangci-lint run --fix
+      types: [go]
+      language: golang
+      require_serial: true
+      pass_filenames: false
+    - name: go generate
+      id: go-generate
+      description: Run go generate to ensure generated files are up-to-date.
+      entry: go generate ./...
+      types: [go, yaml]
+      language: golang
+      require_serial: true
+      pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ This "alpha" client has the following known issues:
 - The `timezoneData` field (used to create a datasource content) is not validated by the API.
 - The `/ui/v1/datasources/{id}` endpoint returns nothing on 404 responses.
 
+### Pre-commit hooks
+
+To catch early some common issues that would be rejected in CI, you can install pre-commit hooks:
+
+1. Install [pre-commit](https://pre-commit.com/#install)
+1. Run:
+
+```
+pre-commit install
+```
+
 ## Thanks
 
 This provider was contributed by [Benjamin Berriot](https://github.com/IIBenII). Many thanks from the Sifflet


### PR DESCRIPTION
Add some basic pre-commit hooks, notably to avoid forgetting `go generate` and have linter issues caught before CI.

They are a bit slow, so we'll see if we keep them. 

CI is still the reference, pre-commits are intended to quicken the feedback loop but are entirely optional.