### PR TITLE
fix: make `sifflet_resource.parameters.source_type` known at plan time

### DIFF
--- a/docs/data-sources/sources.md
+++ b/docs/data-sources/sources.md
@@ -100,7 +100,7 @@ Optional:
 
 Read-Only:
 
-- `source_type` (String) Source type (e.g BIGQUERY, DBT, ...). This attribute is automatically set depending on which connection parameters are set.
+- `source_type` (String) Source type (e.g bigquery, dbt, ...). This attribute is automatically set depending on which connection parameters are set.
 
 <a id="nestedatt--results--parameters--airflow"></a>
 ### Nested Schema for `results.parameters.airflow`

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -106,7 +106,7 @@ Optional:
 
 Read-Only:
 
-- `source_type` (String) Source type (e.g BIGQUERY, DBT, ...). This attribute is automatically set depending on which connection parameters are set.
+- `source_type` (String) Source type (e.g bigquery, dbt, ...). This attribute is automatically set depending on which connection parameters are set.
 
 <a id="nestedatt--parameters--airflow"></a>
 ### Nested Schema for `parameters.airflow`

--- a/internal/client/helpers.go
+++ b/internal/client/helpers.go
@@ -43,7 +43,7 @@ func HandleHttpErrorAsProblem(ctx context.Context, diagnostics *diag.Diagnostics
 	)
 }
 
-// GetSourceType returns the type of the source from the parameters.
+// GetSourceType returns the API type of the source from the parameters (in uppercase).
 // This capability is not natively exposed by the generated client code.
 func GetSourceType(dto PublicGetSourceDto_Parameters) (string, error) {
 	// This function must live in this package, in order to be able to access the private

--- a/internal/provider/source/models.go
+++ b/internal/provider/source/models.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -195,8 +196,15 @@ func (m ParametersModel) AttributeTypes() map[string]attr.Type {
 func (m ParametersModel) TerraformSchema() schema.SingleNestedAttribute {
 	attributes := make(map[string]schema.Attribute)
 	attributes["source_type"] = schema.StringAttribute{
-		Description: "Source type (e.g BIGQUERY, DBT, ...). This attribute is automatically set depending on which connection parameters are set.",
+		Description: "Source type (e.g bigquery, dbt, ...). This attribute is automatically set depending on which connection parameters are set.",
 		Computed:    true,
+		PlanModifiers: []planmodifier.String{
+			// The parent "parameters" attribute has a plan modifier that ensures that the source will be recreated
+			// if the source type changes. Thus, if the source type doesn't change, we can keep the existing state value,
+			// and if it does, the whole resource will be recreated anyway.
+			// A better way woul
+			stringplanmodifier.UseStateForUnknown(),
+		},
 	}
 	for _, t := range allSourceTypes {
 		// A resource-level validator ensure that only one type of parameters is provided
@@ -334,7 +342,12 @@ func parametersDtoToModel(ctx context.Context, dto sifflet.PublicGetSourceDto_Pa
 	if diags.HasError() {
 		return ParametersModel{}, diags
 	}
-	return sourceTypeParams.AsParametersModel(ctx)
+	out, diags := sourceTypeParams.AsParametersModel(ctx)
+	if diags.HasError() {
+		return ParametersModel{}, diags
+	}
+	out.SourceType = types.StringValue(sourceTypeParams.SchemaSourceType())
+	return out, diag.Diagnostics{}
 }
 
 func SourceModelFromDto(ctx context.Context, dto sifflet.PublicGetSourceDto) (SourceModel, diag.Diagnostics) {


### PR DESCRIPTION
Also include a minor documentation fixes about source types in upper vs lower case.

### Notes for reviewers

The main changes are in `ModifyPlan` in `source_resource.go` and `parametersDtoToModel` in `models.go`. Everything else is cleanup to take these changes into account, or tests.