### PR TITLE
fix: work around breaking API change in tag kind capitalization

### DIFF
--- a/internal/provider/source/models.go
+++ b/internal/provider/source/models.go
@@ -292,6 +292,15 @@ func (m *tagModel) FromDto(_ context.Context, dto client.PublicTagReferenceDto) 
 	if dto.Kind != nil {
 		kind = string(*dto.Kind)
 	}
+	// Backwards compatibility. At some point, the API
+	// started returning "TAG", but the resource schema
+	// expects "Tag".
+	if kind == "TAG" {
+		kind = "Tag"
+	}
+	if kind == "CLASSIFICATION" {
+		kind = "Classification"
+	}
 	m.Kind = types.StringValue(kind)
 	return diag.Diagnostics{}
 }


### PR DESCRIPTION
Add support for a breaking change in the source API related to tags. The Sifflet API now returns "TAG" as the `kind` in the tag resource, but the Terraform code expects to see either "Tag" or nothing.

As the `sifflet_source` resource will be removed at some point in favor of a more powerful integration resource, I chose to go for the simplest fix and preserve backwards compatibility with existing Terraform code.