### PR TITLE
fix: allow overriding default timeouts in all resources

### DIFF
--- a/CODING.md
+++ b/CODING.md
@@ -49,6 +49,11 @@ The code manipulates three concepts everywhere:
   variables inside functions. Avoid method signatures that use them as arguments or return values, prefer
   using models instead.
 
+## Timeouts
+
+Use the helper functions `tfutils.WithDefaultCreateTimeout` and similar to add timeouts to all operations.
+For resources where it makes sense, you can add a `timeout` nested attribute to allow the user to override these default timeouts.
+
 ## Resource example
 
 The `sifflet_user` resource is a simple resource that showcases the basic patterns used in the provider.

--- a/internal/provider/credentials/credentials_data_source.go
+++ b/internal/provider/credentials/credentials_data_source.go
@@ -8,6 +8,7 @@ import (
 
 	"terraform-provider-sifflet/internal/apiclients"
 	sifflet "terraform-provider-sifflet/internal/client"
+	"terraform-provider-sifflet/internal/tfutils"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -75,6 +76,9 @@ type CredentialsDataSourceModel struct {
 }
 
 func (d *credentialsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	ctx, cancel := tfutils.WithDefaultReadTimeout(ctx)
+	defer cancel()
+
 	var data CredentialsDataSourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/credentials/credentials_resource.go
+++ b/internal/provider/credentials/credentials_resource.go
@@ -9,6 +9,7 @@ import (
 
 	"terraform-provider-sifflet/internal/apiclients"
 	sifflet "terraform-provider-sifflet/internal/client"
+	"terraform-provider-sifflet/internal/tfutils"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -78,6 +79,9 @@ func (r *credentialsResource) Schema(ctx context.Context, _ resource.SchemaReque
 }
 
 func (r *credentialsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	ctx, cancel := tfutils.WithDefaultCreateTimeout(ctx)
+	defer cancel()
+
 	var plan credentialModel
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -144,6 +148,9 @@ func (r *credentialsResource) Create(ctx context.Context, req resource.CreateReq
 }
 
 func (r *credentialsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	ctx, cancel := tfutils.WithDefaultReadTimeout(ctx)
+	defer cancel()
+
 	var state credentialModel
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -206,6 +213,9 @@ func (r *credentialsResource) Read(ctx context.Context, req resource.ReadRequest
 }
 
 func (r *credentialsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	ctx, cancel := tfutils.WithDefaultUpdateTimeout(ctx)
+	defer cancel()
+
 	var plan credentialModel
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -283,6 +293,9 @@ func (r *credentialsResource) Update(ctx context.Context, req resource.UpdateReq
 }
 
 func (r *credentialsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	ctx, cancel := tfutils.WithDefaultDeleteTimeout(ctx)
+	defer cancel()
+
 	var state credentialModel
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/datasource/datasource_resource.go
+++ b/internal/provider/datasource/datasource_resource.go
@@ -12,6 +12,7 @@ import (
 
 	sifflet "terraform-provider-sifflet/internal/alphaclient"
 	"terraform-provider-sifflet/internal/apiclients"
+	"terraform-provider-sifflet/internal/tfutils"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -50,6 +51,8 @@ func (r *datasourceResource) Schema(ctx context.Context, _ resource.SchemaReques
 
 // Create creates the resource and sets the initial Terraform state.
 func (r *datasourceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	ctx, cancel := tfutils.WithDefaultCreateTimeout(ctx)
+	defer cancel()
 
 	// TODO: Datasources is not tested, can be create with anythings as value
 
@@ -247,6 +250,9 @@ func (r *datasourceResource) Create(ctx context.Context, req resource.CreateRequ
 
 // Read refreshes the Terraform state with the latest data.
 func (r *datasourceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	ctx, cancel := tfutils.WithDefaultReadTimeout(ctx)
+	defer cancel()
+
 	var state CreateDatasourceDto
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -394,6 +400,8 @@ func (r *datasourceResource) Update(ctx context.Context, req resource.UpdateRequ
 
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *datasourceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	ctx, cancel := tfutils.WithDefaultDeleteTimeout(ctx)
+	defer cancel()
 
 	var state CreateDatasourceDto
 	diags := req.State.Get(ctx, &state)

--- a/internal/provider/source/source_resource.go
+++ b/internal/provider/source/source_resource.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	"terraform-provider-sifflet/internal/apiclients"
 	sifflet "terraform-provider-sifflet/internal/client"
 	"terraform-provider-sifflet/internal/provider/datasource"
 	"terraform-provider-sifflet/internal/provider/source/parameters"
+	"terraform-provider-sifflet/internal/tfutils"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
@@ -175,6 +175,8 @@ func (r *sourceResource) Schema(ctx context.Context, _ resource.SchemaRequest, r
 }
 
 func (r *sourceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// No default timeout, this resource implements its own timeouts.
+
 	var plan sourceModel
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -182,7 +184,7 @@ func (r *sourceResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	createTimeout, diags := plan.Timeouts.Create(ctx, 2*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, tfutils.DefaultTimeouts.Create)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -227,6 +229,8 @@ func (r *sourceResource) Create(ctx context.Context, req resource.CreateRequest,
 }
 
 func (r *sourceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// No default timeout, this resource implements its own timeouts.
+
 	var state sourceModel
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -234,7 +238,7 @@ func (r *sourceResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	readTimeout, diags := state.Timeouts.Read(ctx, 2*time.Minute)
+	readTimeout, diags := state.Timeouts.Read(ctx, tfutils.DefaultTimeouts.Read)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -278,6 +282,8 @@ func (r *sourceResource) Read(ctx context.Context, req resource.ReadRequest, res
 }
 
 func (r *sourceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// No default timeout, this resource implements its own timeouts.
+
 	var plan sourceModel
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -285,7 +291,7 @@ func (r *sourceResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	updateTimeout, diags := plan.Timeouts.Update(ctx, 2*time.Minute)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, tfutils.DefaultTimeouts.Update)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -336,6 +342,8 @@ func (r *sourceResource) Update(ctx context.Context, req resource.UpdateRequest,
 }
 
 func (r *sourceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// No default timeout, this resource implements its own timeouts.
+
 	var state sourceModel
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -343,7 +351,7 @@ func (r *sourceResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
-	deleteTimeout, diags := state.Timeouts.Delete(ctx, 2*time.Minute)
+	deleteTimeout, diags := state.Timeouts.Delete(ctx, tfutils.DefaultTimeouts.Delete)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/source/sources_data_source.go
+++ b/internal/provider/source/sources_data_source.go
@@ -210,6 +210,9 @@ func (m FilterModel) ToDto(ctx context.Context) (sifflet.PublicSourceFilterDto, 
 }
 
 func (d *sourcesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	ctx, cancel := tfutils.WithDefaultReadTimeout(ctx)
+	defer cancel()
+
 	var data SourcesDataSourceModel
 	diags := req.Config.Get(ctx, &data)
 	if diags.HasError() {

--- a/internal/provider/tag/tag_resource.go
+++ b/internal/provider/tag/tag_resource.go
@@ -8,6 +8,7 @@ import (
 	sifflet "terraform-provider-sifflet/internal/alphaclient"
 	"terraform-provider-sifflet/internal/apiclients"
 	"terraform-provider-sifflet/internal/client"
+	"terraform-provider-sifflet/internal/tfutils"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -74,6 +75,9 @@ This resource manages 'regular' tags. See the [Sifflet documentation](https://do
 }
 
 func (r *tagResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	ctx, cancel := tfutils.WithDefaultCreateTimeout(ctx)
+	defer cancel()
+
 	var plan tagModel
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -111,6 +115,9 @@ func (r *tagResource) Create(ctx context.Context, req resource.CreateRequest, re
 }
 
 func (r *tagResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	ctx, cancel := tfutils.WithDefaultReadTimeout(ctx)
+	defer cancel()
+
 	var state tagModel
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -152,6 +159,9 @@ func (r *tagResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 }
 
 func (r *tagResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	ctx, cancel := tfutils.WithDefaultUpdateTimeout(ctx)
+	defer cancel()
+
 	var plan tagModel
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -199,6 +209,9 @@ func (r *tagResource) Update(ctx context.Context, req resource.UpdateRequest, re
 }
 
 func (r *tagResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	ctx, cancel := tfutils.WithDefaultDeleteTimeout(ctx)
+	defer cancel()
+
 	var state tagModel
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/tag/tags_data_source.go
+++ b/internal/provider/tag/tags_data_source.go
@@ -10,6 +10,7 @@ import (
 
 	sifflet "terraform-provider-sifflet/internal/alphaclient"
 	"terraform-provider-sifflet/internal/apiclients"
+	"terraform-provider-sifflet/internal/tfutils"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -57,6 +58,9 @@ func (d *tagDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, re
 }
 
 func (d *tagDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	ctx, cancel := tfutils.WithDefaultReadTimeout(ctx)
+	defer cancel()
+
 	var state SearchCollectionTagDto
 
 	ItemsPerPage := int32(-1)

--- a/internal/provider/user/user_resource.go
+++ b/internal/provider/user/user_resource.go
@@ -7,6 +7,7 @@ import (
 
 	"terraform-provider-sifflet/internal/apiclients"
 	sifflet "terraform-provider-sifflet/internal/client"
+	"terraform-provider-sifflet/internal/tfutils"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -107,6 +108,9 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 }
 
 func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	ctx, cancel := tfutils.WithDefaultCreateTimeout(ctx)
+	defer cancel()
+
 	var plan userModel
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -149,6 +153,9 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 }
 
 func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	ctx, cancel := tfutils.WithDefaultReadTimeout(ctx)
+	defer cancel()
+
 	var state userModel
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -191,6 +198,9 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 }
 
 func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	ctx, cancel := tfutils.WithDefaultUpdateTimeout(ctx)
+	defer cancel()
+
 	var plan userModel
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -239,6 +249,9 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 }
 
 func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	ctx, cancel := tfutils.WithDefaultDeleteTimeout(ctx)
+	defer cancel()
+
 	var state userModel
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/tfhttp/client.go
+++ b/internal/tfhttp/client.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 )
@@ -35,7 +34,7 @@ func NewTerraformHttpClient(ctx context.Context, tfVersion string, providerVersi
 	}
 	return &http.Client{
 		Transport: transport,
-		Timeout:   time.Second * 60,
+		// timeouts are provided by contexts, no global timeout here (since it's not possible to override it when a longer timeout would be needed)
 	}
 }
 

--- a/internal/tfutils/timeouts.go
+++ b/internal/tfutils/timeouts.go
@@ -1,0 +1,37 @@
+package tfutils
+
+import (
+	"context"
+	"time"
+)
+
+// DefaultTimeouts defines the default timeout values for all operations for all resources.
+// Individual resources can define a timeout nested attribute to override these defaults:
+// See https://developer.hashicorp.com/terraform/plugin/framework/migrating/resources/timeouts
+var DefaultTimeouts = struct {
+	Create time.Duration
+	Read   time.Duration
+	Update time.Duration
+	Delete time.Duration
+}{
+	Create: 1 * time.Minute,
+	Read:   1 * time.Minute,
+	Update: 1 * time.Minute,
+	Delete: 1 * time.Minute,
+}
+
+func WithDefaultCreateTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, DefaultTimeouts.Create)
+}
+
+func WithDefaultReadTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, DefaultTimeouts.Read)
+}
+
+func WithDefaultUpdateTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, DefaultTimeouts.Update)
+}
+
+func WithDefaultDeleteTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, DefaultTimeouts.Delete)
+}


### PR DESCRIPTION
Issue introduced in #108: the default timeout on the HTTP client still applies, so a user specifying a timeout longer than 1 minute had no effect.

Reported in #106.