### PR TITLE
fix: user resource issues with permissions (sorting, and inconsistencies with ADMIN users)

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -39,7 +39,7 @@ resource "sifflet_user" "example" {
 
 - `email` (String) User email. Also used as a the login identifier. Updates require recreating the user.
 - `name` (String) User full name.
-- `permissions` (Attributes List) Per-domain user permissions. Can not be empty. (see [below for nested schema](#nestedatt--permissions))
+- `permissions` (Set of Attributes) Per-domain user permissions. Can not be empty. (see [below for nested schema](#nestedatt--permissions))
 - `role` (String) User system role. Determines a user's access and permissions over Sifflet-level settings. One of 'ADMIN', 'EDITOR', 'VIEWER'.
 
 ### Optional

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -24,7 +24,8 @@ resource "sifflet_user" "example" {
   email = "user@example.com"
   name  = "Example User"
   role  = "EDITOR"
-  # No matter the system role, all users must have at least one domain role.
+  # VIEWER and EDITOR users must have at least one domain role.
+  # ADMIN users have access to all domains, so none should be set.
   permissions = [{
     domain_id   = data.sifflet_domain.test.id
     domain_role = "VIEWER"
@@ -39,12 +40,12 @@ resource "sifflet_user" "example" {
 
 - `email` (String) User email. Also used as a the login identifier. Updates require recreating the user.
 - `name` (String) User full name.
-- `permissions` (Set of Attributes) Per-domain user permissions. Can not be empty. (see [below for nested schema](#nestedatt--permissions))
 - `role` (String) User system role. Determines a user's access and permissions over Sifflet-level settings. One of 'ADMIN', 'EDITOR', 'VIEWER'.
 
 ### Optional
 
 - `auth_types` (Set of String) Authorized authentication types for the user. Possible values are 'SAML2' and 'LOGIN_PASSWORD'. Default is ['SAML2'] if your Sifflet instance has SSO enabled, and ['LOGIN_PASSWORD', 'SAML2'] otherwise.
+- `permissions` (Attributes Set) Per-domain user permissions. Required for non-ADMIN users (must have at least one entry). Must not be set for ADMIN users: ADMINs are automatically granted editor access on all domains. (see [below for nested schema](#nestedatt--permissions))
 
 ### Read-Only
 
@@ -55,7 +56,7 @@ resource "sifflet_user" "example" {
 
 Required:
 
-- `domain_id` (String) Domain ID. This can be retrieved from the domain details page from the Sifflet UI (there's no public API for this as of this writing).
+- `domain_id` (String) Domain ID. This can be retrieved from the domain details page from the Sifflet UI or from the sifflet_domain data source or resource.
 - `domain_role` (String) User role in the domain. One of 'EDITOR', 'VIEWER', 'CATALOG_EDITOR', 'MONITOR_RESPONDER'.
 
 ## Import

--- a/examples/resources/sifflet_user/resource.tf
+++ b/examples/resources/sifflet_user/resource.tf
@@ -6,7 +6,8 @@ resource "sifflet_user" "example" {
   email = "user@example.com"
   name  = "Example User"
   role  = "EDITOR"
-  # No matter the system role, all users must have at least one domain role.
+  # VIEWER and EDITOR users must have at least one domain role.
+  # ADMIN users have access to all domains, so none should be set.
   permissions = [{
     domain_id   = data.sifflet_domain.test.id
     domain_role = "VIEWER"

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -92,10 +92,10 @@ type InnerModel[D any] interface {
 	AttributeTypes() map[string]attr.Type
 }
 
-// NewModelListFromDto and NewModelSetFromDto are helper functions that creates a Terraform list or set value from a list of DTOs.
-// In the function signature, D is the type of the DTO, and InnerModel[D] is the type of the model that can be created from the DTO.
-// modelCtor is a function that returns a new instance of the model type that matches the DTO type.
-
+// NewModelListFromDto creates a Terraform list value from a slice of DTOs.
+//
+// The type parameter D is the type of the DTO, and InnerModel[D] is the type of the model that can be constructed from the DTO.
+// The modelCtor argument is a function that returns a new instance of the model type corresponding to the DTO type.
 func NewModelListFromDto[D any](ctx context.Context, dtos []D, modelCtor func() InnerModel[D]) (basetypes.ListValue, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
@@ -114,6 +114,10 @@ func NewModelListFromDto[D any](ctx context.Context, dtos []D, modelCtor func() 
 	return result, diags
 }
 
+// NewModelListFromDto creates a Terraform list value from a list of DTOs.
+//
+// The type parameter D is the type of the DTO, and InnerModel[D] is the type of the model that can be constructed from the DTO.
+// The modelCtor argument is a function that returns a new instance of the model type corresponding to the DTO type.
 func NewModelSetFromDto[D any](ctx context.Context, dtos []D, modelCtor func() InnerModel[D]) (basetypes.SetValue, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -92,9 +92,10 @@ type InnerModel[D any] interface {
 	AttributeTypes() map[string]attr.Type
 }
 
-// NewModelListFromDto is a helper function that creates a Terraform list value from a list of DTOs.
+// NewModelListFromDto and NewModelSetFromDto are helper functions that creates a Terraform list or set value from a list of DTOs.
 // In the function signature, D is the type of the DTO, and InnerModel[D] is the type of the model that can be created from the DTO.
 // modelCtor is a function that returns a new instance of the model type that matches the DTO type.
+
 func NewModelListFromDto[D any](ctx context.Context, dtos []D, modelCtor func() InnerModel[D]) (basetypes.ListValue, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
@@ -109,6 +110,24 @@ func NewModelListFromDto[D any](ctx context.Context, dtos []D, modelCtor func() 
 	diags.Append(ds...)
 
 	result, ds := types.ListValueFrom(ctx, attrType, modelList)
+	diags.Append(ds...)
+	return result, diags
+}
+
+func NewModelSetFromDto[D any](ctx context.Context, dtos []D, modelCtor func() InnerModel[D]) (basetypes.SetValue, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	// zero value used only to call AttributeTypes
+	attrType := types.ObjectType{AttrTypes: modelCtor().AttributeTypes()}
+
+	modelList, ds := tfutils.MapWithDiagnostics(dtos, func(dto D) (InnerModel[D], diag.Diagnostics) {
+		model := modelCtor()
+		diags := model.FromDto(ctx, dto)
+		return model, diags
+	})
+	diags.Append(ds...)
+
+	result, ds := types.SetValueFrom(ctx, attrType, modelList)
 	diags.Append(ds...)
 	return result, diags
 }

--- a/internal/provider/user/models.go
+++ b/internal/provider/user/models.go
@@ -18,7 +18,7 @@ type userModel struct {
 	Name        types.String `tfsdk:"name"`
 	Email       types.String `tfsdk:"email"`
 	Role        types.String `tfsdk:"role"`
-	Permissions types.List   `tfsdk:"permissions"`
+	Permissions types.Set    `tfsdk:"permissions"`
 	AuthTypes   types.Set    `tfsdk:"auth_types"`
 }
 
@@ -120,7 +120,7 @@ func (m userModel) ToUpdateDto(ctx context.Context) (sifflet.PublicUserUpdateDto
 }
 
 func (m *userModel) FromDto(ctx context.Context, userDto sifflet.PublicUserGetDto) diag.Diagnostics {
-	permissionsList, diags := model.NewModelListFromDto(
+	permissionsList, diags := model.NewModelSetFromDto(
 		ctx, userDto.Permissions,
 		func() model.InnerModel[sifflet.PublicUserPermissionAssignmentDto] { return &permissionModel{} },
 	)

--- a/internal/provider/user/models.go
+++ b/internal/provider/user/models.go
@@ -119,6 +119,14 @@ func (m userModel) ToUpdateDto(ctx context.Context) (sifflet.PublicUserUpdateDto
 	}, diag.Diagnostics{}
 }
 
+// clearPermissionsForAdmin sets permissions to null for ADMIN users.
+// ADMIN users have permissions auto-assigned by the API on all domains, so we don't manage them in state.
+func clearPermissionsForAdmin(state *userModel) {
+	if state.Role.ValueString() == "ADMIN" {
+		state.Permissions = types.SetNull(types.ObjectType{AttrTypes: permissionModel{}.AttributeTypes()})
+	}
+}
+
 func (m *userModel) FromDto(ctx context.Context, userDto sifflet.PublicUserGetDto) diag.Diagnostics {
 	permissionsList, diags := model.NewModelSetFromDto(
 		ctx, userDto.Permissions,
@@ -139,6 +147,7 @@ func (m *userModel) FromDto(ctx context.Context, userDto sifflet.PublicUserGetDt
 	m.Role = types.StringValue(string(userDto.Role))
 	m.Permissions = permissionsList
 	m.AuthTypes = authTypes
+	clearPermissionsForAdmin(m)
 	return diag.Diagnostics{}
 }
 

--- a/internal/provider/user/user_resource.go
+++ b/internal/provider/user/user_resource.go
@@ -9,7 +9,6 @@ import (
 	sifflet "terraform-provider-sifflet/internal/client"
 	"terraform-provider-sifflet/internal/tfutils"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -19,11 +18,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 var (
-	_ resource.Resource              = &userResource{}
-	_ resource.ResourceWithConfigure = &userResource{}
+	_ resource.Resource                 = &userResource{}
+	_ resource.ResourceWithConfigure    = &userResource{}
+	_ resource.ResourceWithUpgradeState = &userResource{}
 )
 
 func newUserResource() resource.Resource {
@@ -41,6 +42,7 @@ func (r *userResource) Metadata(_ context.Context, req resource.MetadataRequest,
 
 func userResourceSchema() schema.Schema {
 	return schema.Schema{
+		Version:             1,
 		Description:         "Manage a Sifflet user.",
 		MarkdownDescription: "Manage a Sifflet user. See the [Sifflet documentation about access control](https://docs.siffletdata.com/docs/access-control) for more information.\n\nWarning: creating a user will send an email to the specified email address giving them instructions on how to connect to the Sifflet environment.",
 		Attributes: map[string]schema.Attribute{
@@ -67,13 +69,13 @@ func userResourceSchema() schema.Schema {
 				Description: "User system role. Determines a user's access and permissions over Sifflet-level settings. One of 'ADMIN', 'EDITOR', 'VIEWER'.",
 				Required:    true,
 			},
-			"permissions": schema.ListNestedAttribute{
+			"permissions": schema.SetNestedAttribute{
 				Description: "Per-domain user permissions. Can not be empty.",
 				Required:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"domain_id": schema.StringAttribute{
-							Description: "Domain ID. This can be retrieved from the domain details page from the Sifflet UI (there's no public API for this as of this writing).",
+							Description: "Domain ID. This can be retrieved from the domain details page from the Sifflet UI or from the sifflet_domain data source or resource.",
 							Required:    true,
 						},
 						"domain_role": schema.StringAttribute{
@@ -82,9 +84,9 @@ func userResourceSchema() schema.Schema {
 						},
 					},
 				},
-				// The API will return an error if the list is empty. It's an easy mistake to make, so add client-side validation.
-				Validators: []validator.List{
-					listvalidator.SizeAtLeast(1),
+				// The API will return an error if the set is empty. It's an easy mistake to make, so add client-side validation.
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
 				},
 			},
 			"auth_types": schema.SetAttribute{
@@ -296,4 +298,80 @@ func (r *userResource) Configure(_ context.Context, req resource.ConfigureReques
 	}
 
 	r.client = clients.Client
+}
+
+func (r *userResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	// Build v0 schema by copying v1 and overriding only the changed attribute
+	v0Schema := userResourceSchema()
+	v0Schema.Version = 0
+
+	// Override permissions to be ListNestedAttribute (v0) instead of SetNestedAttribute (v1)
+	v0Schema.Attributes["permissions"] = schema.ListNestedAttribute{
+		Description: "Per-domain user permissions. Can not be empty.",
+		Required:    true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"domain_id": schema.StringAttribute{
+					Description: "Domain ID.",
+					Required:    true,
+				},
+				"domain_role": schema.StringAttribute{
+					Description: "User role in the domain.",
+					Required:    true,
+				},
+			},
+		},
+	}
+
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &v0Schema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				type userModelV0 struct {
+					Id          types.String `tfsdk:"id"`
+					Name        types.String `tfsdk:"name"`
+					Email       types.String `tfsdk:"email"`
+					Role        types.String `tfsdk:"role"`
+					Permissions types.List   `tfsdk:"permissions"`
+					AuthTypes   types.Set    `tfsdk:"auth_types"`
+				}
+
+				var priorState userModelV0
+				resp.Diagnostics.Append(req.State.Get(ctx, &priorState)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				// Convert permissions from List to Set
+				permissionAttrTypes := permissionModel{}.AttributeTypes()
+				var permissionsUpgraded types.Set
+				if !priorState.Permissions.IsNull() && !priorState.Permissions.IsUnknown() {
+					var permissionObjs []types.Object
+					resp.Diagnostics.Append(priorState.Permissions.ElementsAs(ctx, &permissionObjs, false)...)
+					if resp.Diagnostics.HasError() {
+						return
+					}
+					var ds basetypes.SetValue
+					ds, resp.Diagnostics = types.SetValueFrom(ctx, types.ObjectType{AttrTypes: permissionAttrTypes}, permissionObjs)
+					if resp.Diagnostics.HasError() {
+						return
+					}
+					permissionsUpgraded = ds
+				} else {
+					permissionsUpgraded = types.SetNull(types.ObjectType{AttrTypes: permissionAttrTypes})
+				}
+
+				upgradedState := userModel{
+					Id:          priorState.Id,
+					Name:        priorState.Name,
+					Email:       priorState.Email,
+					Role:        priorState.Role,
+					Permissions: permissionsUpgraded,
+					AuthTypes:   priorState.AuthTypes,
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedState)...)
+			},
+		},
+	}
 }

--- a/internal/provider/user/user_resource.go
+++ b/internal/provider/user/user_resource.go
@@ -22,9 +22,11 @@ import (
 )
 
 var (
-	_ resource.Resource                 = &userResource{}
-	_ resource.ResourceWithConfigure    = &userResource{}
-	_ resource.ResourceWithUpgradeState = &userResource{}
+	_ resource.Resource                     = &userResource{}
+	_ resource.ResourceWithConfigure        = &userResource{}
+	_ resource.ResourceWithUpgradeState     = &userResource{}
+	_ resource.ResourceWithConfigValidators = &userResource{}
+	_ resource.ResourceWithModifyPlan       = &userResource{}
 )
 
 func newUserResource() resource.Resource {
@@ -70,8 +72,8 @@ func userResourceSchema() schema.Schema {
 				Required:    true,
 			},
 			"permissions": schema.SetNestedAttribute{
-				Description: "Per-domain user permissions. Can not be empty.",
-				Required:    true,
+				Description: "Per-domain user permissions. Required for non-ADMIN users (must have at least one entry). Must not be set for ADMIN users: ADMINs are automatically granted editor access on all domains.",
+				Optional:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"domain_id": schema.StringAttribute{
@@ -83,10 +85,6 @@ func userResourceSchema() schema.Schema {
 							Required:    true,
 						},
 					},
-				},
-				// The API will return an error if the set is empty. It's an easy mistake to make, so add client-side validation.
-				Validators: []validator.Set{
-					setvalidator.SizeAtLeast(1),
 				},
 			},
 			"auth_types": schema.SetAttribute{
@@ -107,6 +105,70 @@ func userResourceSchema() schema.Schema {
 
 func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = userResourceSchema()
+}
+
+// permissionsAdminValidator enforces that:
+//   - ADMIN users must not have permissions set (the API auto-assigns editor access on all domains)
+//   - non-ADMIN users must have at least one permission entry
+type permissionsAdminValidator struct{}
+
+func (v permissionsAdminValidator) Description(_ context.Context) string {
+	return "Validates that permissions is not set for ADMIN users and has at least one entry for non-ADMIN users."
+}
+
+func (v permissionsAdminValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v permissionsAdminValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config userModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	isAdmin := config.Role.ValueString() == "ADMIN"
+	permissionsSet := !config.Permissions.IsNull() && len(config.Permissions.Elements()) > 0
+
+	if isAdmin && permissionsSet {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("permissions"),
+			"permissions must not be set for ADMIN users",
+			"ADMIN users are automatically granted editor access on all domains. Do not provide the permissions attribute.",
+		)
+	} else if !isAdmin && !permissionsSet {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("permissions"),
+			"permissions must be set for non-ADMIN users",
+			"Non-ADMIN users must have at least one domain permission entry.",
+		)
+	}
+}
+
+func (r userResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		permissionsAdminValidator{},
+	}
+}
+
+// ModifyPlan ensures that permissions is null in the plan for ADMIN users, preventing
+// "Provider produced inconsistent result after apply" errors when transitioning to/from ADMIN.
+func (r *userResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Nothing to do when destroying
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan userModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.Role.ValueString() == "ADMIN" {
+		plan.Permissions = types.SetNull(types.ObjectType{AttrTypes: permissionModel{}.AttributeTypes()})
+		resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+	}
 }
 
 func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/user/user_resource_state_upgrade_test.go
+++ b/internal/provider/user/user_resource_state_upgrade_test.go
@@ -115,14 +115,3 @@ func TestUserResourceStateUpgradeV0(t *testing.T) {
 		}
 	})
 }
-
-func TestUserResourceSchemaVersion(t *testing.T) {
-	schema := userResourceSchema()
-	if schema.Version != 1 {
-		t.Errorf("Expected schema version 1, got %d", schema.Version)
-	}
-}
-
-func TestUserResourceImplementsUpgradeState(t *testing.T) {
-	var _ resource.ResourceWithUpgradeState = &userResource{}
-}

--- a/internal/provider/user/user_resource_state_upgrade_test.go
+++ b/internal/provider/user/user_resource_state_upgrade_test.go
@@ -1,0 +1,128 @@
+package user
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var permissionTftypeObject = tftypes.Object{
+	AttributeTypes: map[string]tftypes.Type{
+		"domain_id":   tftypes.String,
+		"domain_role": tftypes.String,
+	},
+}
+
+func TestUserResourceStateUpgradeV0(t *testing.T) {
+	ctx := context.Background()
+	r := &userResource{}
+	upgraders := r.UpgradeState(ctx)
+	upgraderV0 := upgraders[0]
+	priorSchema := upgraderV0.PriorSchema
+
+	t.Run("upgrade_permissions_list_to_set", func(t *testing.T) {
+		rawStateValue := tftypes.NewValue(
+			priorSchema.Type().TerraformType(ctx),
+			map[string]tftypes.Value{
+				"id":    tftypes.NewValue(tftypes.String, "00000000-0000-0000-0000-000000000001"),
+				"name":  tftypes.NewValue(tftypes.String, "Test User"),
+				"email": tftypes.NewValue(tftypes.String, "test@example.com"),
+				"role":  tftypes.NewValue(tftypes.String, "EDITOR"),
+				"permissions": tftypes.NewValue(
+					tftypes.List{ElementType: permissionTftypeObject},
+					[]tftypes.Value{
+						tftypes.NewValue(permissionTftypeObject, map[string]tftypes.Value{
+							"domain_id":   tftypes.NewValue(tftypes.String, "aaaabbbb-aaaa-bbbb-aaaa-bbbbaaaabbbb"),
+							"domain_role": tftypes.NewValue(tftypes.String, "VIEWER"),
+						}),
+						tftypes.NewValue(permissionTftypeObject, map[string]tftypes.Value{
+							"domain_id":   tftypes.NewValue(tftypes.String, "ccccdddd-cccc-dddd-cccc-ddddccccdddd"),
+							"domain_role": tftypes.NewValue(tftypes.String, "EDITOR"),
+						}),
+					},
+				),
+				"auth_types": tftypes.NewValue(
+					tftypes.Set{ElementType: tftypes.String},
+					[]tftypes.Value{
+						tftypes.NewValue(tftypes.String, "SAML2"),
+					},
+				),
+			},
+		)
+
+		req := resource.UpgradeStateRequest{
+			State: &tfsdk.State{
+				Raw:    rawStateValue,
+				Schema: *priorSchema,
+			},
+		}
+
+		resp := &resource.UpgradeStateResponse{
+			State: tfsdk.State{
+				Schema: userResourceSchema(),
+			},
+		}
+
+		upgraderV0.StateUpgrader(ctx, req, resp)
+
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("Unexpected error: %v", resp.Diagnostics)
+		}
+
+		var upgradedState userModel
+		resp.State.Get(ctx, &upgradedState)
+
+		// Verify other fields are preserved
+		if upgradedState.Id.ValueString() != "00000000-0000-0000-0000-000000000001" {
+			t.Errorf("Expected id %q, got %q", "00000000-0000-0000-0000-000000000001", upgradedState.Id.ValueString())
+		}
+		if upgradedState.Email.ValueString() != "test@example.com" {
+			t.Errorf("Expected email %q, got %q", "test@example.com", upgradedState.Email.ValueString())
+		}
+		if upgradedState.Role.ValueString() != "EDITOR" {
+			t.Errorf("Expected role %q, got %q", "EDITOR", upgradedState.Role.ValueString())
+		}
+
+		// Verify permissions is not null and contains the right elements
+		if upgradedState.Permissions.IsNull() {
+			t.Fatal("permissions should not be null after upgrade")
+		}
+
+		var permissions []permissionModel
+		upgradedState.Permissions.ElementsAs(ctx, &permissions, false)
+
+		if len(permissions) != 2 {
+			t.Fatalf("Expected 2 permissions, got %d", len(permissions))
+		}
+
+		// Verify all permissions are preserved (as a set, order is not guaranteed)
+		expectedPermissions := map[string]string{
+			"aaaabbbb-aaaa-bbbb-aaaa-bbbbaaaabbbb": "VIEWER",
+			"ccccdddd-cccc-dddd-cccc-ddddccccdddd": "EDITOR",
+		}
+		for _, p := range permissions {
+			expectedRole, ok := expectedPermissions[p.DomainId.ValueString()]
+			if !ok {
+				t.Errorf("Unexpected domain_id %q in upgraded permissions", p.DomainId.ValueString())
+				continue
+			}
+			if p.DomainRole.ValueString() != expectedRole {
+				t.Errorf("Expected domain_role %q for domain %q, got %q", expectedRole, p.DomainId.ValueString(), p.DomainRole.ValueString())
+			}
+		}
+	})
+}
+
+func TestUserResourceSchemaVersion(t *testing.T) {
+	schema := userResourceSchema()
+	if schema.Version != 1 {
+		t.Errorf("Expected schema version 1, got %d", schema.Version)
+	}
+}
+
+func TestUserResourceImplementsUpgradeState(t *testing.T) {
+	var _ resource.ResourceWithUpgradeState = &userResource{}
+}

--- a/internal/provider/user/user_resource_test.go
+++ b/internal/provider/user/user_resource_test.go
@@ -2,18 +2,21 @@ package user_test
 
 import (
 	"fmt"
+	"regexp"
+	sifflet "terraform-provider-sifflet/internal/client"
 	"terraform-provider-sifflet/internal/provider"
 	"terraform-provider-sifflet/internal/provider/providertests"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccUserResourceBasic(t *testing.T) {
 	userEmail := providertests.RandomEmail()
-	// As of this writing, there's no public API for domains.
-	// However, all tenants have by default a domain named "All" with this static ID.
+
+	// All tenants have by default a domain named "All" with this static ID.
 	// This is suitable for testing purposes (this domain will be present in any newly created tenant, and
 	// is also present in QA tenants).
 	domainId := "aaaabbbb-aaaa-bbbb-aaaa-bbbbaaaabbbb"
@@ -36,7 +39,11 @@ func TestAccUserResourceBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sifflet_user.test", "email", userEmail),
 					resource.TestCheckResourceAttrSet("sifflet_user.test", "id"),
-					resource.TestCheckResourceAttr("sifflet_user.test", "auth_types.0", "SAML2"),
+					resource.TestCheckTypeSetElemAttr("sifflet_user.test", "auth_types.*", "SAML2"),
+					resource.TestCheckTypeSetElemNestedAttrs("sifflet_user.test", "permissions.*", map[string]string{
+						"domain_id":   domainId,
+						"domain_role": "VIEWER",
+					}),
 				),
 			},
 			{
@@ -61,7 +68,32 @@ func TestAccUserResourceBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("sifflet_user.test", "name", "Updated name"),
 					resource.TestCheckResourceAttr("sifflet_user.test", "role", "EDITOR"),
 					resource.TestCheckResourceAttrSet("sifflet_user.test", "id"),
-					resource.TestCheckResourceAttr("sifflet_user.test", "auth_types.0", "SAML2"),
+					resource.TestCheckTypeSetElemAttr("sifflet_user.test", "auth_types.*", "SAML2"),
+					resource.TestCheckTypeSetElemNestedAttrs("sifflet_user.test", "permissions.*", map[string]string{
+						"domain_id":   domainId,
+						"domain_role": "EDITOR",
+					}),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("sifflet_user.test", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				Config: providertests.ProviderConfig() + fmt.Sprintf(`
+						resource "sifflet_user" "test" {
+							email = "%s"
+							name = "Updated name"
+							role = "ADMIN"
+						}
+						`, userEmail),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sifflet_user.test", "name", "Updated name"),
+					resource.TestCheckResourceAttr("sifflet_user.test", "role", "ADMIN"),
+					resource.TestCheckResourceAttrSet("sifflet_user.test", "id"),
+					resource.TestCheckNoResourceAttr("sifflet_user.test", "permissions.#"),
+					resource.TestCheckTypeSetElemAttr("sifflet_user.test", "auth_types.*", "SAML2"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -73,13 +105,13 @@ func TestAccUserResourceBasic(t *testing.T) {
 	})
 }
 
-func TestAccUserResourceOptionalAttributes(t *testing.T) {
+func TestAccUserResourceAuthTypesAttributes(t *testing.T) {
 	userEmail := providertests.RandomEmail()
-	// As of this writing, there's no public API for domains.
-	// However, all tenants have by default a domain named "All" with this static ID.
+
+	// All tenants have by default a domain named "All" with this static ID.
 	// This is suitable for testing purposes (this domain will be present in any newly created tenant, and
 	// is also present in QA tenants).
-	domainId := "aaaabbbb-aaaa-bbbb-aaaa-bbbbaaaabbbb"
+	allDomainId := "aaaabbbb-aaaa-bbbb-aaaa-bbbbaaaabbbb"
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
@@ -98,12 +130,13 @@ func TestAccUserResourceOptionalAttributes(t *testing.T) {
 							// that this does not introduce a bug
 							auth_types = ["SAML2", "LOGIN_PASSWORD"]
 						}
-						`, userEmail, domainId),
+						`, userEmail, allDomainId),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sifflet_user.test", "email", userEmail),
 					resource.TestCheckResourceAttrSet("sifflet_user.test", "id"),
-					resource.TestCheckResourceAttr("sifflet_user.test", "auth_types.0", "LOGIN_PASSWORD"),
-					resource.TestCheckResourceAttr("sifflet_user.test", "auth_types.1", "SAML2"),
+					resource.TestCheckResourceAttr("sifflet_user.test", "auth_types.#", "2"),
+					resource.TestCheckTypeSetElemAttr("sifflet_user.test", "auth_types.*", "LOGIN_PASSWORD"),
+					resource.TestCheckTypeSetElemAttr("sifflet_user.test", "auth_types.*", "SAML2"),
 				),
 			},
 			{
@@ -124,18 +157,219 @@ func TestAccUserResourceOptionalAttributes(t *testing.T) {
 							}]
 							auth_types = ["LOGIN_PASSWORD"]
 						}
-						`, userEmail, domainId),
+						`, userEmail, allDomainId),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sifflet_user.test", "name", "Updated name"),
 					resource.TestCheckResourceAttr("sifflet_user.test", "role", "EDITOR"),
 					resource.TestCheckResourceAttrSet("sifflet_user.test", "id"),
-					resource.TestCheckResourceAttr("sifflet_user.test", "auth_types.0", "LOGIN_PASSWORD"),
+					resource.TestCheckResourceAttr("sifflet_user.test", "auth_types.#", "1"),
+					resource.TestCheckTypeSetElemAttr("sifflet_user.test", "auth_types.*", "LOGIN_PASSWORD"),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("sifflet_user.test", plancheck.ResourceActionUpdate),
 					},
 				},
+			},
+		},
+	})
+}
+
+func TestAccUserResourcePermissionsAttributes(t *testing.T) {
+	// Set up for creating a domain
+	ctx := t.Context()
+	client, err := providertests.ClientForTests(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	workspaceName := providertests.RandomName()
+	assetUri := providertests.RandomGithubDeclaredAssetUri()
+	assetDescription := "Created by Terraform provider tests"
+	assetName := providertests.SessionPrefix() + " " + assetUri
+	subTypeName := "TerraformTest"
+
+	domainName := providertests.RandomName()
+
+	// All tenants have by default a domain named "All" with this static ID.
+	// This is suitable for testing purposes (this domain will be present in any newly created tenant, and
+	// is also present in QA tenants).
+	allDomainId := "aaaabbbb-aaaa-bbbb-aaaa-bbbbaaaabbbb"
+
+	userEmail := providertests.RandomEmail()
+
+	// domainConfig is reused across steps as the domain resource itself never changes.
+	domainConfig := fmt.Sprintf(`
+		resource "sifflet_domain" "test" {
+			name = "%s"
+			description = "Created by Terraform provider tests"
+			dynamic_content_definition = {
+				logical_operator = "AND"
+				conditions = [{
+					logical_operator = "IS"
+					schema_uris = ["github://github.com/%s"]
+				}]
+			}
+		}
+	`, domainName, providertests.SessionPrefix())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			// Create the declared assets
+			asset := sifflet.PublicDeclarativeAssetDto{
+				Uri:         assetUri,
+				Description: &assetDescription,
+				Name:        &assetName,
+				Type:        sifflet.Generic,
+				SubType:     &subTypeName,
+			}
+			err := providertests.CreateDeclaredAssets(ctx, client, workspaceName, &[]sifflet.PublicDeclarativeAssetDto{asset})
+			if err != nil {
+				t.Fatalf("Failed to create declared assets: %v", err)
+			}
+		},
+		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providertests.ProviderConfig() + domainConfig + fmt.Sprintf(`
+					resource "sifflet_user" "test" {
+						email = "%s"
+						name = "Terraform Test User"
+						role = "VIEWER"
+						permissions = [{
+							domain_id = "%s"
+							domain_role = "VIEWER"
+						}, {
+							domain_id = sifflet_domain.test.id
+							domain_role = "EDITOR"
+						}]
+					}
+					`, userEmail, allDomainId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sifflet_user.test", "email", userEmail),
+					resource.TestCheckResourceAttrSet("sifflet_user.test", "id"),
+					resource.TestCheckResourceAttr("sifflet_user.test", "role", "VIEWER"),
+					resource.TestCheckResourceAttr("sifflet_user.test", "permissions.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs("sifflet_user.test", "permissions.*", map[string]string{
+						"domain_id":   allDomainId,
+						"domain_role": "VIEWER",
+					}),
+				),
+			},
+			{
+				ResourceName:                         "sifflet_user.test",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "id",
+			},
+			{
+				// Change order of permissions to check that it has no effect (permissions is a set)
+				Config: providertests.ProviderConfig() + domainConfig + fmt.Sprintf(`
+					resource "sifflet_user" "test" {
+						email = "%s"
+						name = "Terraform Test User"
+						role = "VIEWER"
+						permissions = [{
+							domain_id = sifflet_domain.test.id
+							domain_role = "EDITOR"
+						}, {
+							domain_id = "%s"
+							domain_role = "VIEWER"
+						}]
+					}
+					`, userEmail, allDomainId),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("sifflet_user.test", plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				Config: providertests.ProviderConfig() + domainConfig + fmt.Sprintf(`
+					resource "sifflet_user" "test" {
+						email = "%s"
+						name = "Terraform Test User"
+						role = "ADMIN"
+					}
+					`, userEmail),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sifflet_user.test", "email", userEmail),
+					resource.TestCheckResourceAttrSet("sifflet_user.test", "id"),
+					resource.TestCheckResourceAttr("sifflet_user.test", "role", "ADMIN"),
+					resource.TestCheckNoResourceAttr("sifflet_user.test", "permissions.#"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("sifflet_user.test", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+		CheckDestroy: func(s *terraform.State) error {
+			// Delete the declared assets and all related resources
+			err := providertests.DeleteDeclaredAssets(ctx, client, workspaceName)
+			return err
+		},
+	})
+}
+
+func TestAccUserInvalidConfig(t *testing.T) {
+	userEmail := providertests.RandomEmail()
+
+	allDomainId := "aaaabbbb-aaaa-bbbb-aaaa-bbbbaaaabbbb"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// No permissions provided on non-ADMIN user
+				Config: providertests.ProviderConfig() + fmt.Sprintf(`
+					resource "sifflet_user" "test" {
+						email = "%s"
+						name = "Terraform Test User"
+						role = "VIEWER"
+					}
+				`, userEmail),
+				ExpectError: regexp.MustCompile("permissions must be set for non-ADMIN users"),
+			},
+			{
+				// Empty permissions provided on non-ADMIN user
+				Config: providertests.ProviderConfig() + fmt.Sprintf(`
+					resource "sifflet_user" "test" {
+						email = "%s"
+						name = "Terraform Test User"
+						role = "VIEWER"
+						permissions = []
+					}
+				`, userEmail),
+				ExpectError: regexp.MustCompile("permissions must be set for non-ADMIN users"),
+			},
+			{
+				// Permissions provided on ADMIN user
+				Config: providertests.ProviderConfig() + fmt.Sprintf(`
+					resource "sifflet_user" "test" {
+						email = "%s"
+						name = "Terraform Test User"
+						role = "ADMIN"
+						permissions = [{
+							domain_id = "%s"
+							domain_role = "VIEWER"
+						}]
+					}
+				`, userEmail, allDomainId),
+				ExpectError: regexp.MustCompile("permissions must not be set for ADMIN users"),
+			},
+			{
+				// Empty auth_types provided
+				Config: providertests.ProviderConfig() + fmt.Sprintf(`
+					resource "sifflet_user" "test" {
+						email = "%s"
+						name = "Terraform Test User"
+						role = "ADMIN"
+						auth_types = []
+					}
+				`, userEmail),
+				ExpectError: regexp.MustCompile("Attribute auth_types set must contain at least 1 elements, got: 0"),
 			},
 		},
 	})


### PR DESCRIPTION
This MR fixes two issues on the `permissions` field of `sifflet_user` resource:
- Sorting problems as the API returns elements in a different order than the user sets: transformed the list into a set as the order does not matter
- Inconsistencies with ADMIN users: the app considers that ADMIN users are EDITOR on all domains and sets them as such in the backend. This means that the permissions set by the user are overriden and do not correspond to the config returned by the backend. This MR thus requires the `permissions` field to not be set for ADMIN users. It also sets the value to null for admin users so that the state doesn't require changing every time a domain is added/removed.

These fixes are separated into two commits that can be reviewed separately.